### PR TITLE
Avoid to use a setter to set the null value

### DIFF
--- a/ORM/NullableEmbeddableListener.php
+++ b/ORM/NullableEmbeddableListener.php
@@ -43,7 +43,11 @@ final class NullableEmbeddableListener
             }
 
             if ($embeddable->isNull()) {
-                $this->propertyAccessor->setValue($object, $propertyPath, null);
+                $nullator = \Closure::bind(function ($property) {
+                    $this->{$property} = null;
+                }, $object, get_class($object));
+
+                $nullator($propertyPath);
             }
         }
     }


### PR DESCRIPTION
Hello,

The listener you provide uses the property accessor. But value objects never imply the need of a setter. Doctrine doesn't either. So using a setter means to force the user to add a setter.

This PR fix the issue. Of course, there are drawbacks:
- This is ugly (well, doctrine do worst, so why not? :D)
- It was working with property paths, not anymore (did somebody really used a property path to null through many objects/arrays?)

Hope you'll like it :).

✅ Tests pass!