### PR TITLE
PHP 8 support (drops PHP 7.0/7.1)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,11 +10,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: [7.4, 8.0, 8.1, 8.2]
+        php: [7.4, 8.0, 8.1, 8.2, 8.3]
         experimental: [false]
-        include:
-          - php: 8.3
-            experimental: true
 
     steps:
       - name: Checkout

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,39 @@
+name: PHP Tests
+
+on: [push, pull_request]
+
+jobs:
+  tests:
+    name: 'Tests PHP ${{ matrix.php }}'
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        php: [7.4, 8.0, 8.1, 8.2]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        
+      - name: Set up PHP ${{ matrix.php }}
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+
+      - name: Validate composer.json and composer.lock
+        run: composer validate --strict
+
+      - name: Cache Composer packages
+        id: composer-cache
+        uses: actions/cache@v2
+        with:
+          path: vendor
+          key: ${{ runner.os }}-php${{ matrix.php }}-${{ hashFiles('**/composer.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-php${{ matrix.php }}-
+
+      - name: Install dependencies
+        run: composer install --prefer-dist --no-progress --no-interaction
+
+      - name: Tests
+        run: vendor/bin/phpunit

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,7 @@ jobs:
 
       - name: Cache Composer packages
         id: composer-cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: vendor
           key: ${{ runner.os }}-php${{ matrix.php }}-${{ hashFiles('**/composer.lock') }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,10 +6,15 @@ jobs:
   tests:
     name: 'Tests PHP ${{ matrix.php }}'
     runs-on: ubuntu-latest
+    continue-on-error: ${{ matrix.experimental }}
     strategy:
       fail-fast: false
       matrix:
         php: [7.4, 8.0, 8.1, 8.2]
+        experimental: [false]
+        include:
+          - php: 8.3
+            experimental: true
 
     steps:
       - name: Checkout

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,7 @@ jobs:
 
       - name: Cache Composer packages
         id: composer-cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: vendor
           key: ${{ runner.os }}-php${{ matrix.php }}-${{ hashFiles('**/composer.lock') }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 composer.lock
 /vendor/
+.phpunit*.cache

--- a/Tests/NullableEmbeddable/ClosureNullatorTest.php
+++ b/Tests/NullableEmbeddable/ClosureNullatorTest.php
@@ -21,7 +21,7 @@ final class ClosureNullatorTest extends TestCase
      */
     private $listener;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->listener = NullableEmbeddableListenerFactory::createWithClosureNullator();
     }

--- a/Tests/NullableEmbeddable/NullableEmbeddableListenerTest.php
+++ b/Tests/NullableEmbeddable/NullableEmbeddableListenerTest.php
@@ -21,7 +21,7 @@ final class NullableEmbeddableListenerTest extends TestCase
      */
     private $listener;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->listener = NullableEmbeddableListenerFactory::createWithPropertyAccessor();
     }

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     "minimum-stability": "stable",
     "require": {
         "php": "^7.0",
-        "symfony/property-access": "^3.2|^4.0"
+        "symfony/property-access": "^3.2|^5.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^5.7"

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     "minimum-stability": "stable",
     "require": {
         "php": "^7.2 || ^8.0",
-        "symfony/property-access": "^3.2 || ^4.0 || ^5.0 || ^6.0"
+        "symfony/property-access": "^3.2 || ^4.0 || ^5.0 || ^6.0 || ^7.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^8.5 || ^9.5 || ^10.0"

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     "minimum-stability": "stable",
     "require": {
         "php": "^7.0",
-        "symfony/property-access": "^3.2|^5.0"
+        "symfony/property-access": "^3.2 || ^4.0 || ^5.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^5.7"

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     "minimum-stability": "stable",
     "require": {
         "php": "^7.2 || ^8.0",
-        "symfony/property-access": "^3.2 || ^4.0 || ^5.0"
+        "symfony/property-access": "^3.2 || ^4.0 || ^5.0 || ^6.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^8.5 || ^9.5"

--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,6 @@
         "symfony/property-access": "^3.2 || ^4.0 || ^5.0 || ^6.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^8.5 || ^9.5"
+        "phpunit/phpunit": "^8.5 || ^9.5 || ^10.0"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -14,10 +14,10 @@
 
     "minimum-stability": "stable",
     "require": {
-        "php": "^7.0",
+        "php": "^7.2 || ^8.0",
         "symfony/property-access": "^3.2 || ^4.0 || ^5.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^5.7"
+        "phpunit/phpunit": "^8.5 || ^9.5"
     }
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,33 +1,32 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
 <!-- https://phpunit.de/documentation.html -->
 <phpunit
-        backupGlobals               = "false"
-        backupStaticAttributes      = "false"
-        colors                      = "true"
-        convertErrorsToExceptions   = "true"
-        convertNoticesToExceptions  = "true"
-        convertWarningsToExceptions = "true"
-        processIsolation            = "false"
-        stopOnFailure               = "true"
-        stopOnError                 = "true"
-        syntaxCheck                 = "false"
-        forceCoversAnnotation       = "true"
-        bootstrap                   = "./vendor/autoload.php">
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/8.5/phpunit.xsd"
+    backupGlobals="false"
+    backupStaticAttributes="false"
+    colors="true"
+    convertErrorsToExceptions="true"
+    convertNoticesToExceptions="true"
+    convertWarningsToExceptions="true"
+    processIsolation="false"
+    stopOnFailure="true"
+    stopOnError="true"
+    forceCoversAnnotation="true"
+    bootstrap="./vendor/autoload.php">
+  <testsuites>
+    <testsuite name="default">
+      <directory>./Tests</directory>
+    </testsuite>
+  </testsuites>
 
-    <testsuites>
-        <testsuite>
-            <directory>./Tests</directory>
-        </testsuite>
-    </testsuites>
-
-    <filter>
-        <whitelist>
-            <directory>.</directory>
-            <exclude>
-                <directory>./Tests</directory>
-                <directory suffix="Interface.php">./*</directory>
-            </exclude>
-        </whitelist>
-    </filter>
+  <filter>
+    <whitelist>
+      <directory>.</directory>
+      <exclude>
+        <directory>./Tests</directory>
+        <directory suffix="Interface.php">./*</directory>
+      </exclude>
+    </whitelist>
+  </filter>
 </phpunit>


### PR DESCRIPTION
This builds on #7 (approved but not yet merged) to add PHP 8 support, dropping support for PHP 7.0/7.1.

- PHPUnit upgraded: minimum required version is 8.x (requires PHP >= 7.2)
